### PR TITLE
[BugFix] fix setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,24 +25,24 @@ zip_safe = True
 include_package_data = True
 python_requires = >= 3.9, < 3.11
 install_requires = 
-	numpy >= 1.21.*, < 2
-	scipy >= 1.4.*, < 2
-	dask[complete] >= 2.12.*, < 2022.12
-	sparse >= 0.13.*, < 1
-	numba >= 0.51.*, < 1
-	pandas >= 1.2.*, < 2
-	matplotlib >= 3.3.*, < 4
-	tqdm >= 4.61.*, < 5
-	statsmodels >= 0.13.*, < 1
+	numpy >= 1.21, < 2
+	scipy >= 1.4, < 2
+	dask[complete] >= 2.12, < 2022.12
+	sparse >= 0.13, < 1
+	numba >= 0.51, < 1
+	pandas >= 1.2, < 2
+	matplotlib >= 3.3, < 4
+	tqdm >= 4.61, < 5
+	statsmodels >= 0.13, < 1
 	pycsou @ git+https://github.com/matthieumeo/pycsou@v2-dev
 	periodispline @ git+https://github.com/matthieumeo/periodispline@c423c48e48e3d4643ebb330470506559ff8932ed
 
 [options.extras_require]
 dev = 
-	sphinx == 2.1.*
+	sphinx == 2.1
 	jinja2 < 3.1
 _gpu = 
-	cupy >= 10.0.*, < 12
+	cupy >= 10.0, < 12
 complete_no_gpu = 
 complete_gpu = 
-	cupy >= 10.0.*, < 12
+	cupy >= 10.0, < 12


### PR DESCRIPTION
Remove the '.*' characters after the version numbers in the install_requires section, that create an error when running 'pip install .'.